### PR TITLE
Update HideButtonGlow.lua

### DIFF
--- a/HideButtonGlow.lua
+++ b/HideButtonGlow.lua
@@ -99,9 +99,11 @@ if ElvUI then
 	if LibCustomGlow and LibCustomGlow.ShowOverlayGlow then
 		local OriginalShowOverlayGlow = LibCustomGlow.ShowOverlayGlow
 		function LibCustomGlow.ShowOverlayGlow(self)
-			local spellId = self:GetSpellId()
-			if spellId and addon:ShouldHideGlow(spellId) then
-				return
+			if self:GetSpellId() then
+				local spellId = self:GetSpellId()
+				if spellId and addon:ShouldHideGlow(spellId) then
+					return
+				end
 			end
 			return OriginalShowOverlayGlow(self)
 		end


### PR DESCRIPTION
fixed an error while clicking on the dungeon group finder icon in the micro menu in cata classic with elvui and bartender:

```
22x HideButtonGlow/HideButtonGlow.lua:103: attempt to call method 'GetSpellId' (a nil value)
[string "@HideButtonGlow/HideButtonGlow.lua"]:103: in function `ShowOverlayGlow'
[string "@ElvUI/Cata/Modules/Skins/LFG.lua"]:17: in function <ElvUI/Cata/Modules/Skins/LFG.lua:16>
[string "=[C]"]: in function `Show'
[string "@Blizzard_GroupFinder/Classic/PVEFrame.lua"]:345: in function `GroupFinderFrame_ShowGroupFrame'
[string "@Blizzard_GroupFinder/Classic/PVEFrame.lua"]:307: in function `update'
[string "@Blizzard_GroupFinder/Classic/PVEFrame.lua"]:150: in function `PVEFrame_ShowFrame'
[string "@Blizzard_GroupFinder/Classic/PVEFrame.lua"]:96: in function `PVEFrame_ToggleFrame'
[string "*MainMenuBarMicroButtons.xml:372_OnMouseUp"]:5: in function <[string "*MainMenuBarMicroButtons.xml:372_OnMouseUp"]:1>

Locals:
self = CheckButton {
 0 = <userdata>
 backdrop = Frame {
 }
 SetCheckedTexture = <function> defined =[C]:-1
 SetHighlightTexture = <function> defined =[C]:-1
 SetPushedTexture = <function> defined =[C]:-1
 isSkinned = true
 onClick = <function> defined @Blizzard_GroupFinder/Classic/LFDFrame.lua:150
 SetNormalTexture = <function> defined =[C]:-1
}
(*temporary) = nil
(*temporary) = CheckButton {
 0 = <userdata>
 backdrop = Frame {
 }
 SetCheckedTexture = <function> defined =[C]:-1
 SetHighlightTexture = <function> defined =[C]:-1
 SetPushedTexture = <function> defined =[C]:-1
 isSkinned = true
 onClick = <function> defined @Blizzard_GroupFinder/Classic/LFDFrame.lua:150
 SetNormalTexture = <function> defined =[C]:-1
}
(*temporary) = "attempt to call method 'GetSpellId' (a nil value)" addon = <table> {
 AddMessage = <function> defined @HideButtonGlow/HideButtonGlow.lua:41
 ShouldHideGlow = <function> defined @HideButtonGlow/HideButtonGlow.lua:45
}
OriginalShowOverlayGlow = <function> defined @ElvUI/Core/init.lua:180
```